### PR TITLE
fix: handle txs with no L2ToL1 logs emitted gracefully

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -77,6 +77,7 @@ async function simRetryable(sr: SimulationResult, simname: string) {
   const parentId = proposal.id!
 
   const rawlog = sim.transaction.transaction_info.logs?.map((l) => l.raw)
+  if(!rawlog) return []
   const bridgeMessages = parseTypedLogs(Bridge__factory, rawlog as any, 'MessageDelivered')
   const inboxMessages = parseTypedLogs(Inbox__factory, rawlog as any, 'InboxMessageDelivered(uint256,bytes)')
   if (bridgeMessages.length !== inboxMessages.length) {

--- a/index.ts
+++ b/index.ts
@@ -45,6 +45,7 @@ async function simL2toL1(sr: SimulationResult, simname: string) {
   const parentId = proposal.id!
 
   const rawlog = sim.transaction.transaction_info.logs?.map((l) => l.raw)
+  if(!rawlog) return []
   const L2ToL1TxEvents = parseTypedLogs(ArbSys__factory, rawlog as any, 'L2ToL1Tx')
 
   const simresults = []

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -395,6 +395,7 @@ async function simulateProposed(config: SimulationConfigProposed): Promise<Simul
     // this need to be L1 block number but simBlock is L2 block number
     // cannot use 0, but also need be less than current, so using 1 as a dummy value here
     governorStateOverrides = {
+      [`${proposalCoreKey}.voteStart._deadline`]: '1',
       [`${proposalCoreKey}.voteEnd._deadline`]: '1',
       [`${proposalCoreKey}.canceled`]: 'false',
       [`${proposalCoreKey}.executed`]: 'false',


### PR DESCRIPTION
still not working for AIP 1.1 but this makes it not crash