### PR TITLE
fix: ignored state change

### DIFF
--- a/checks/check-state-changes.ts
+++ b/checks/check-state-changes.ts
@@ -67,13 +67,6 @@ export const checkStateChanges: ProposalCheck = {
       // mapping within a single `diff` element. We always JSON.stringify the values so structs
       // (i.e. tuples) don't print as [object Object]
       diffs.forEach((diff) => {
-        // Sometimes Tenderly will return state changes where the original value is null, which
-        // means the original and dirty (new) values are the same. This is currently a bug, but it
-        // only happens when the original and dirty values match (i.e. no storage was changed,
-        // because the slot went from original -> other value -> original). As a result we can
-        // safely skip these diffs.
-        if (diff.original === null) return
-
         if (!diff.soltype) {
           // In this branch, state change is not decoded, so return raw data of each storage write
           // (all other branches have decoded state changes)


### PR DESCRIPTION
Tenderly no longer return `diff.original === null` for storage slot that went from `original -> other value -> original`, but instead will have `diff.original === null` for undecoded slot. Removing the ignore to make sure seatbelt surface those storage changes.

Can test with https://github.com/ArbitrumFoundation/governance-seatbelt/pull/26
before
```
*   TransparentUpgradeableProxy at `0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6`
    *   Slot `0x0000000000000000000000000000000000000000000000000000000000000004` changed from `"0x0000000000000000000000000000000000000000000000000000000000001680"` to `"0x0000000000000000000000000000000000000000000000000000000000000000"`
    *   Slot `0x0000000000000000000000000000000000000000000000000000000000000005` changed from `"0x000000000000000000000000000000000000000000000000000000000000000c"` to `"0x0000000000000000000000000000000000000000000000000000000000000000"`
    *   Slot `0x0000000000000000000000000000000000000000000000000000000000000006` changed from `"0x0000000000000000000000000000000000000000000000000000000000015180"` to `"0x0000000000000000000000000000000000000000000000000000000000000000"`
    *   Slot `0x0000000000000000000000000000000000000000000000000000000000000007` changed from `"0x0000000000000000000000000000000000000000000000000000000000000e10"` to `"0x0000000000000000000000000000000000000000000000000000000000000000"`
```
after
```
*   TransparentUpgradeableProxy at `0x1c479675ad559DC151F6Ec7ed3FbF8ceE79582B6`
    *   Slot `0x0000000000000000000000000000000000000000000000000000000000000004` changed from `"0x0000000000000000000000000000000000000000000000000000000000001680"` to `"0x0000000000000000000000000000000000000000000000000000000000000000"`
    *   Slot `0x0000000000000000000000000000000000000000000000000000000000000005` changed from `"0x000000000000000000000000000000000000000000000000000000000000000c"` to `"0x0000000000000000000000000000000000000000000000000000000000000000"`
    *   Slot `0x0000000000000000000000000000000000000000000000000000000000000006` changed from `"0x0000000000000000000000000000000000000000000000000000000000015180"` to `"0x0000000000000000000000000000000000000000000000000000000000000000"`
    *   Slot `0x0000000000000000000000000000000000000000000000000000000000000007` changed from `"0x0000000000000000000000000000000000000000000000000000000000000e10"` to `"0x0000000000000000000000000000000000000000000000000000000000000000"`
    *   Slot `0x000000000000000000000000000000000000000000000000000000000000000a` changed from `"0x0000000000000000000000000000000000000000000000000000000000000000"` to `"0x0000000000000300000000000001518000000000000000400000000000001680"`
    *   Slot `0x000000000000000000000000000000000000000000000000000000000000000b` changed from `"0x0000000000000000000000000000000000000000000000000000000000000000"` to `"0x000000000000000000000000d0fda6925f502a3a94986dfe7c92fe19ebbd679b"`
    *   Slot `0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc` changed from `"0x000000000000000000000000d03bfe2ce83632f4e618a97299cc91b1335bb2d9"` to `"0x00000000000000000000000031da64d19cd31a19cd09f4070366fe2144792cf7"`
```