### PR TITLE
perf: pending only and other qol improvments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,6 @@ TENDERLY_PROJECT_SLUG=yourTenderlyProjectSlug
 DAO_NAME=ArbCore
 GOVERNOR_ADDRESS=0xf07ded9dc292157749b6fd268e37df6ea38395b9
 
-# If this is set, the script will only simulate proposal in pending states
+# If this is set, the script will only simulate proposal that is not executed and may be executed in the future
 # including Pending, Active, Queued and Succeeded.
-ONLY_PENDING=true
+ONLY_RELEVANT=true

--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ TENDERLY_PROJECT_SLUG=yourTenderlyProjectSlug
 DAO_NAME=ArbCore
 GOVERNOR_ADDRESS=0xf07ded9dc292157749b6fd268e37df6ea38395b9
 
+# If this is set, the script will only simulate proposal in pending states
+# including Pending, Active, Queued and Succeeded.
+ONLY_PENDING=true

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -82,4 +82,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.DAO_NAME }}
-          path: reports/${{ matrix.DAO_NAME }}/${{ matrix.GOVERNOR_ADDRESS }}/**
+          path: reports/${{ matrix.DAO_NAME }}/${{ matrix.GOVERNOR_ADDRESS }}/

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -17,8 +17,10 @@ jobs:
         include:
           - DAO_NAME: 'ArbCore'
             GOVERNOR_ADDRESS: '0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9'
+            ONLY_PENDING: true
           - DAO_NAME: 'ArbTreasury'
             GOVERNOR_ADDRESS: '0x789fC99093B09aD01C34DC7251D0C89ce743e5a4'
+            ONLY_PENDING: true
 
     name: Check all live proposals
     runs-on: ubuntu-latest

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -17,10 +17,10 @@ jobs:
         include:
           - DAO_NAME: 'ArbCore'
             GOVERNOR_ADDRESS: '0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9'
-            ONLY_PENDING: true
+            ONLY_RELEVANT: true
           - DAO_NAME: 'ArbTreasury'
             GOVERNOR_ADDRESS: '0x789fC99093B09aD01C34DC7251D0C89ce743e5a4'
-            ONLY_PENDING: true
+            ONLY_RELEVANT: true
 
     name: Check all live proposals
     runs-on: ubuntu-latest

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -82,4 +82,4 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.DAO_NAME }}
-          path: reports/${{ matrix.DAO_NAME }}/${{ matrix.GOVERNOR_ADDRESS }}/
+          path: reports/${{ matrix.DAO_NAME }}/${{ matrix.GOVERNOR_ADDRESS }}/**

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -74,6 +74,9 @@ jobs:
           DAO_NAME: ${{ matrix.DAO_NAME }}
           GOVERNOR_ADDRESS: ${{ matrix.GOVERNOR_ADDRESS }}
           ONLY_RELEVANT: ${{ matrix.ONLY_RELEVANT }}
+      
+      - name: List reports
+        run: find reports/${{ matrix.DAO_NAME }}/${{ matrix.GOVERNOR_ADDRESS }}/
 
       - name: Upload artifacts
         # We always upload artifacts, even if certain proposal sims/checks failed. This is because

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -73,6 +73,7 @@ jobs:
           TENDERLY_PROJECT_SLUG: ${{ secrets.TENDERLY_PROJECT_SLUG }}
           DAO_NAME: ${{ matrix.DAO_NAME }}
           GOVERNOR_ADDRESS: ${{ matrix.GOVERNOR_ADDRESS }}
+          ONLY_RELEVANT: ${{ matrix.ONLY_RELEVANT }}
 
       - name: Upload artifacts
         # We always upload artifacts, even if certain proposal sims/checks failed. This is because

--- a/.github/workflows/governance-checks.yaml
+++ b/.github/workflows/governance-checks.yaml
@@ -74,9 +74,6 @@ jobs:
           DAO_NAME: ${{ matrix.DAO_NAME }}
           GOVERNOR_ADDRESS: ${{ matrix.GOVERNOR_ADDRESS }}
           ONLY_RELEVANT: ${{ matrix.ONLY_RELEVANT }}
-      
-      - name: List reports
-        run: find reports/${{ matrix.DAO_NAME }}/${{ matrix.GOVERNOR_ADDRESS }}/
 
       - name: Upload artifacts
         # We always upload artifacts, even if certain proposal sims/checks failed. This is because

--- a/checks/check-state-changes.ts
+++ b/checks/check-state-changes.ts
@@ -24,8 +24,8 @@ export const checkStateChanges: ProposalCheck = {
     // (2) the `proposal.executed` change of the governor, because this will be consistent across
     // all proposals and mainly add noise to the output
     if (!sim.transaction.transaction_info.state_diff) {
-      console.log('State diff is empty, printing sim response')
-      console.log(JSON.stringify(sim, null, 2))
+      const warnings = `State diff is empty`
+      return { info: [], warnings: [warnings], errors: [] }
     }
     const stateDiffs = sim.transaction.transaction_info.state_diff.reduce((diffs, diff) => {
       const addr = getAddress(diff.raw[0].address)

--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ async function simL2toL1(sr: SimulationResult, simname: string) {
       signatures: [''], // Array of function signatures. Leave empty if generating calldata with ethers like we do here.
       calldatas: [l2ToL1TxEvent.data], // Array of encoded calldatas.
       description: 'The is the L1 Timelock Execution of simulation ' + parentId.toHexString(),
-      parentId: parentId.div(10000000).mul(10000000),
+      parentId: parentId.div(10000000).add(1).mul(10000000),
       idoffset: offset,
     }
     offset += 1000000 // reserve spaces for retryable exections

--- a/index.ts
+++ b/index.ts
@@ -60,7 +60,7 @@ async function simL2toL1(sr: SimulationResult, simname: string) {
       values: [l2ToL1TxEvent.callvalue], // Array of values with each call.
       signatures: [''], // Array of function signatures. Leave empty if generating calldata with ethers like we do here.
       calldatas: [l2ToL1TxEvent.data], // Array of encoded calldatas.
-      description: 'The is the L1 Timelock Execution of simulation ' + parentId.toHexString(),
+      description: '# The is the L1 Timelock Execution of simulation ' + parentId.toHexString(),
       parentId: parentId.div(10000000).add(1).mul(10000000),
       idoffset: offset,
     }
@@ -119,7 +119,7 @@ async function simRetryable(sr: SimulationResult, simname: string) {
         values: [parsedRetryable.l2CallValue], // Array of values with each call.
         signatures: [''], // Array of function signatures. Leave empty if generating calldata with ethers like we do here.
         calldatas: [parsedRetryable.data], // Array of encoded calldatas.
-        description: 'The is the L2 Retryable Execution of simulation ' + parentId.toHexString(),
+        description: '# The is the L2 Retryable Execution of simulation ' + parentId.toHexString(),
         parentId: parentId,
         idoffset: offset,
       }

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@
 
 import dotenv from 'dotenv'
 dotenv.config()
-import { BigNumber, BigNumberish, Contract } from 'ethers'
+import { BigNumber, BigNumberish, Contract, constants } from 'ethers'
 import { DAO_NAME, GOVERNOR_ADDRESS, SIM_NAME } from './utils/constants'
 import { arb1provider, l1provider, provider } from './utils/clients/ethers'
 import { simulate } from './utils/clients/tenderly'
@@ -55,7 +55,7 @@ async function simL2toL1(sr: SimulationResult, simname: string) {
       type: 'arbl2tol1',
       daoName: simname,
       governorType: 'arb',
-      governorAddress: '0xf07ded9dc292157749b6fd268e37df6ea38395b9',
+      governorAddress: getAddress(GOVERNOR_ADDRESS || constants.AddressZero),
       targets: [l2ToL1TxEvent.destination], // Array of targets to call.
       values: [l2ToL1TxEvent.callvalue], // Array of values with each call.
       signatures: [''], // Array of function signatures. Leave empty if generating calldata with ethers like we do here.
@@ -114,7 +114,7 @@ async function simRetryable(sr: SimulationResult, simname: string) {
         from: bridgeMessageEvent.sender,
         daoName: simname,
         governorType: 'arb',
-        governorAddress: '0xf07ded9dc292157749b6fd268e37df6ea38395b9',
+        governorAddress: getAddress(GOVERNOR_ADDRESS || constants.AddressZero),
         targets: [parsedRetryable.destAddress], // Array of targets to call.
         values: [parsedRetryable.l2CallValue], // Array of values with each call.
         signatures: [''], // Array of function signatures. Leave empty if generating calldata with ethers like we do here.

--- a/index.ts
+++ b/index.ts
@@ -191,7 +191,7 @@ async function main() {
       const proposalState = PROPOSAL_STATES[state]
       return { id, proposalState}
     }).filter(p => {
-      return !process.env.ONLY_PENDING ||
+      return !process.env.ONLY_RELEVANT ||
               p.proposalState === 'Pending' || 
               p.proposalState === 'Active' || 
               p.proposalState === 'Queued' || 

--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ async function simL2toL1(sr: SimulationResult, simname: string) {
       signatures: [''], // Array of function signatures. Leave empty if generating calldata with ethers like we do here.
       calldatas: [l2ToL1TxEvent.data], // Array of encoded calldatas.
       description: 'The is the L1 Timelock Execution of simulation ' + parentId.toHexString(),
-      parentId: parentId,
+      parentId: parentId.div(10000000).mul(10000000),
       idoffset: offset,
     }
     offset += 1000000 // reserve spaces for retryable exections
@@ -218,7 +218,7 @@ async function main() {
     for (const simProposal of simProposals) {
       if (simProposal.simType === 'new') throw new Error('Simulation type "new" is not supported in this branch')
       // Determine if this proposal is already `executed` or currently in-progress (`proposed`)
-      console.log(`  Simulating ${DAO_NAME} proposal ${simProposal.id}...`)
+      console.log(`  Simulating ${DAO_NAME} proposal ${simProposal.id} ...`)
       const config: SimulationConfig = {
         type: simProposal.simType,
         daoName: DAO_NAME,
@@ -253,7 +253,7 @@ async function main() {
   for (const simOutput of simOutputs) {
     // Run checks
     const { sim, proposal, latestBlock, config } = simOutput
-    console.log(`  Running for proposal ID ${formatProposalId(governorType, proposal.id!)}...`)
+    console.log(`  Running for proposal ID ${formatProposalId(governorType, proposal.id!)} ...`)
     const checkResults: AllCheckResults = Object.fromEntries(
       await Promise.all(
         Object.keys(ALL_CHECKS).map(async (checkId) => [

--- a/index.ts
+++ b/index.ts
@@ -60,7 +60,7 @@ async function simL2toL1(sr: SimulationResult, simname: string) {
       values: [l2ToL1TxEvent.callvalue], // Array of values with each call.
       signatures: [''], // Array of function signatures. Leave empty if generating calldata with ethers like we do here.
       calldatas: [l2ToL1TxEvent.data], // Array of encoded calldatas.
-      description: '# The is the L1 Timelock Execution of simulation ' + parentId.toHexString(),
+      description: `# This is a L1 Timelock Execution of simulation ${parentId.toString()}\n .`,
       parentId: parentId.div(10000000).add(1).mul(10000000),
       idoffset: offset,
     }
@@ -119,7 +119,7 @@ async function simRetryable(sr: SimulationResult, simname: string) {
         values: [parsedRetryable.l2CallValue], // Array of values with each call.
         signatures: [''], // Array of function signatures. Leave empty if generating calldata with ethers like we do here.
         calldatas: [parsedRetryable.data], // Array of encoded calldatas.
-        description: '# The is the L2 Retryable Execution of simulation ' + parentId.toHexString(),
+        description: `# This is a L2 Retryable Execution of simulation ${parentId.toString()} \n.`,
         parentId: parentId,
         idoffset: offset,
       }

--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -142,8 +142,17 @@ export async function generateAndSaveReports(
 ) {
   // Prepare the output folder and filename.
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+  const pdfdir = `${dir}/pdf`
+  if (!fs.existsSync(pdfdir)) fs.mkdirSync(pdfdir, { recursive: true })
+  const mdDir = `${dir}/md`
+  if (!fs.existsSync(mdDir)) fs.mkdirSync(mdDir, { recursive: true })
+  const htmlDir = `${dir}/html`
+  if (!fs.existsSync(htmlDir)) fs.mkdirSync(htmlDir, { recursive: true })
+
   const id = formatProposalId(governorType, proposal.id!)
-  const path = `${dir}/${id}`
+  const pdfpath = `${pdfdir}/${id}`
+  const mdpath = `${mdDir}/${id}`
+  const htmlpath = `${htmlDir}/${id}`
 
   // Generate the base markdown proposal report. This is the markdown report which is translated into other file types.
   const baseReport = await toMarkdownProposalReport(governorType, blocks, proposal, checks, simid)
@@ -166,9 +175,9 @@ export async function generateAndSaveReports(
 
   // Save off all reports. The Markdown and PDF reports use the `markdownReport`.
   await Promise.all([
-    fsp.writeFile(`${path}.html`, htmlReport),
-    fsp.writeFile(`${path}.md`, markdownReport),
-    mdToPdf({ content: markdownReport }, { dest: `${path}.pdf` }),
+    fsp.writeFile(`${htmlpath}.html`, htmlReport),
+    fsp.writeFile(`${mdpath}.md`, markdownReport),
+    mdToPdf({ content: markdownReport }, { dest: `${pdfpath}.pdf` }),
   ])
 }
 

--- a/utils/contracts/governor.ts
+++ b/utils/contracts/governor.ts
@@ -211,7 +211,7 @@ export async function getImplementation(address: string, blockTag: number) {
 }
 
 export function formatProposalId(governorType: GovernorType, id: BigNumberish) {
-  if (governorType === 'oz' || governorType === 'arb') return BigNumber.from(id).toHexString()
+  if (governorType === 'oz') return BigNumber.from(id).toHexString()
   return BigNumber.from(id).toString()
 }
 


### PR DESCRIPTION
Add a new ONLY_RELEVANT envvar to make it only generate reports for relevant (including pending, active, queued, succeeded) proposals.

Also changed the proposal naming scheme so that it is easier to link to the tally page e.g.
https://www.tally.xyz/gov/arbitrum/proposal/28300903567340237987946172947371304329455149918972967618773111648600015289785
https://www.tally.xyz/gov/arbitrum/proposal/46905320292877192134536823079608810426433248493109520384601548724615383601450

```
$ ts-node --experimental-specifier-resolution node index.ts
Your primary provider is connected to networkID 42161
Simulating 2 ArbCore proposals: IDs of 28300903567340237987946172947371304329455149918972967618773111648600015289785, 46905320292877192134536823079608810426433248493109520384601548724615383601450
  Simulating ArbCore proposal 28300903567340237987946172947371304329455149918972967618773111648600015289785 ...
    done
  Simulating ArbCore proposal 46905320292877192134536823079608810426433248493109520384601548724615383601450 ...
    done
Starting proposal checks and report generation...
  Running for proposal ID 28300903567340237987946172947371304329455149918972967618773111648600015289785 ... // tally proposal id
  Running for proposal ID 28300903567340237987946172947371304329455149918972967618773111648600020000001 ... // first withdrawal
  Running for proposal ID 28300903567340237987946172947371304329455149918972967618773111648600020010001 ... // first retryable
  Running for proposal ID 46905320292877192134536823079608810426433248493109520384601548724615383601450 ... // tally proposal id
  Running for proposal ID 46905320292877192134536823079608810426433248493109520384601548724615390000001 ... // first withdrawal
  Running for proposal ID 46905320292877192134536823079608810426433248493109520384601548724615390010001 ... // first retryable
Done!
```

Also storing the html, pdf, and md report in separate directories:

```
.
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/pdf
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/pdf/28300903567340237987946172947371304329455149918972967618773111648600015289785.pdf
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/pdf/46905320292877192134536823079608810426433248493109520384601548724615390010001.pdf
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/pdf/46905320292877192134536823079608810426433248493109520384601548724615390000001.pdf
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/pdf/46905320292877192134536823079608810426433248493109520384601548724615383601450.pdf
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/pdf/28300903567340237987946172947371304329455149918972967618773111648600020010001.pdf
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/pdf/28300903567340237987946172947371304329455149918972967618773111648600020000001.pdf
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/html
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/html/46905320292877192134536823079608810426433248493109520384601548724615383601450.html
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/html/28300903567340237987946172947371304329455149918972967618773111648600020000001.html
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/html/28300903567340237987946172947371304329455149918972967618773111648600020010001.html
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/html/46905320292877192134536823079608810426433248493109520384601548724615390000001.html
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/html/46905320292877192134536823079608810426433248493109520384601548724615390010001.html
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/html/28300903567340237987946172947371304329455149918972967618773111648600015289785.html
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/md
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/md/28300903567340237987946172947371304329455149918972967618773111648600020000001.md
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/md/46905320292877192134536823079608810426433248493109520384601548724615383601450.md
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/md/46905320292877192134536823079608810426433248493109520384601548724615390010001.md
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/md/28300903567340237987946172947371304329455149918972967618773111648600015289785.md
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/md/28300903567340237987946172947371304329455149918972967618773111648600020010001.md
./0xf07DeD9dC292157749B6Fd268E37DF6EA38395B9/md/46905320292877192134536823079608810426433248493109520384601548724615390000001.md
```

[46905320292877192134536823079608810426433248493109520384601548724615383601450.md](https://github.com/ArbitrumFoundation/governance-seatbelt/files/14298088/46905320292877192134536823079608810426433248493109520384601548724615383601450.md)
[46905320292877192134536823079608810426433248493109520384601548724615390010001.md](https://github.com/ArbitrumFoundation/governance-seatbelt/files/14298086/46905320292877192134536823079608810426433248493109520384601548724615390010001.md)
[46905320292877192134536823079608810426433248493109520384601548724615390000001.md](https://github.com/ArbitrumFoundation/governance-seatbelt/files/14298087/46905320292877192134536823079608810426433248493109520384601548724615390000001.md)

[28300903567340237987946172947371304329455149918972967618773111648600015289785.md](https://github.com/ArbitrumFoundation/governance-seatbelt/files/14298091/28300903567340237987946172947371304329455149918972967618773111648600015289785.md)
[28300903567340237987946172947371304329455149918972967618773111648600020010001.md](https://github.com/ArbitrumFoundation/governance-seatbelt/files/14298089/28300903567340237987946172947371304329455149918972967618773111648600020010001.md)
[28300903567340237987946172947371304329455149918972967618773111648600020000001.md](https://github.com/ArbitrumFoundation/governance-seatbelt/files/14298090/28300903567340237987946172947371304329455149918972967618773111648600020000001.md)


Also merged in https://github.com/Uniswap/governance-seatbelt/pull/127 to fix an issue where tenderly return empty state diff