### PR TITLE
Disable PDF Reports

### DIFF
--- a/presentation/report.ts
+++ b/presentation/report.ts
@@ -177,7 +177,7 @@ export async function generateAndSaveReports(
   await Promise.all([
     fsp.writeFile(`${htmlpath}.html`, htmlReport),
     fsp.writeFile(`${mdpath}.md`, markdownReport),
-    mdToPdf({ content: markdownReport }, { dest: `${pdfpath}.pdf` }),
+    // mdToPdf({ content: markdownReport }, { dest: `${pdfpath}.pdf` }),
   ])
 }
 


### PR DESCRIPTION
There is a bug in PDF report generation. PDF reports aren't strictly necessary, so easiest fix is to disable them