### PR TITLE
fix: getLatestBlock endpoint and make retryable sims non-fatal

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -130,8 +130,18 @@ async function simRetryable(sr: SimulationResult, simname: string) {
         chainId: chainId
       }
       offset += 10000
-      const { sim, proposal, latestBlock } = await simulate(l2tol1config)
-      simresults.push({ sim, proposal, latestBlock, config: l2tol1config })
+      try {
+        const { sim, proposal, latestBlock } = await simulate(l2tol1config)
+        simresults.push({ sim, proposal, latestBlock, config: l2tol1config })
+      } catch (err) {
+        // Nova (42170) is a documented unsupported chain (see README Known Issues); do not
+        // let one chain's retryable simulation abort the whole run.
+        console.warn(
+          `WARNING: skipping retryable simulation on chain ${chainId} (status ${
+            (err as any)?.statusCode ?? 'unknown'
+          }). Nova is a known-unsupported chain.`
+        )
+      }
     }
   }
   return simresults

--- a/utils/clients/tenderly.ts
+++ b/utils/clients/tenderly.ts
@@ -796,11 +796,11 @@ export function getContractName(contract: TenderlyContract | undefined, defaultN
  */
 async function getLatestBlock(chainId: BigNumberish): Promise<number> {
   try {
-    // Send simulation request
-    const url = `${TENDERLY_BASE_URL}/network/${BigNumber.from(chainId).toString()}/block-number`
-    const fetchOptions = <Partial<FETCH_OPT>>{ method: 'GET', ...TENDERLY_FETCH_OPTIONS }
-    const res = await fetchUrl(url, fetchOptions)
-    return res.block_number as number
+    // The legacy Tenderly `/network/{chainId}/block-number` gateway endpoint was removed
+    // (returns 404), so read the latest block from the chain's RPC provider instead.
+    const id = BigNumber.from(chainId).toNumber()
+    const chainProvider = id === 1 ? l1provider : id === 42170 ? novaprovider : arb1provider
+    return await chainProvider.getBlockNumber()
   } catch (err) {
     console.log('logging getLatestBlock error')
     console.log(JSON.stringify(err, null, 2))


### PR DESCRIPTION
utils/clients/tenderly.ts: the legacy Tenderly /network/{chainId}/block-number endpoint returns 404; read the latest block from the RPC provider instead.

index.ts: wrap each per-chain retryable simulation in try/catch so an unsupported chain (Nova) does not abort the whole run.